### PR TITLE
Implement chat history screen

### DIFF
--- a/lib/ui/screens/chat_history_screen.dart
+++ b/lib/ui/screens/chat_history_screen.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+import '../../models/chat_session.dart';
+import '../../providers/chat_providers.dart';
+
+class ChatHistoryScreen extends ConsumerWidget {
+  const ChatHistoryScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final sessions = ref.watch(chatSessionsProvider);
+    final activeSession = ref.watch(activeChatSessionProvider);
+
+    if (sessions.isEmpty) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('Chat History')),
+        body: const Center(child: Text('No chat history')),
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Chat History')),
+      body: ListView.builder(
+        itemCount: sessions.length,
+        itemBuilder: (context, index) {
+          final session = sessions[index];
+          final isActive = activeSession?.id == session.id;
+          return ListTile(
+            title: Text(session.title),
+            subtitle: Text('Last updated: '
+                '${DateFormat.yMd().add_jm().format(session.updatedAt)}'),
+            trailing: isActive ? const Icon(Icons.check) : null,
+            onTap: () {
+              ref
+                  .read(activeChatSessionProvider.notifier)
+                  .setActiveSession(session);
+              Navigator.pop(context);
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/ui/screens/chat_screen.dart
+++ b/lib/ui/screens/chat_screen.dart
@@ -4,6 +4,7 @@ import '../../models/message.dart';
 import '../../providers/chat_providers.dart';
 import '../widgets/message_bubble.dart';
 import '../widgets/service_selector.dart';
+import 'chat_history_screen.dart';
 
 class ChatScreen extends ConsumerWidget {
   const ChatScreen({super.key});
@@ -26,6 +27,18 @@ class ChatScreen extends ConsumerWidget {
                   .createNewSession(serviceType);
             },
             tooltip: 'New Chat',
+          ),
+          IconButton(
+            icon: const Icon(Icons.history),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => const ChatHistoryScreen(),
+                ),
+              );
+            },
+            tooltip: 'Chat History',
           ),
           const ServiceSelector(),
         ],


### PR DESCRIPTION
## Summary
- add ChatHistoryScreen to view list of chat sessions
- allow navigating to history from chat screen

## Testing
- `flutter test` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cfd47e9a08322ace4508f5dd50122