### PR TITLE
Add chat session renaming

### DIFF
--- a/lib/providers/chat_providers.dart
+++ b/lib/providers/chat_providers.dart
@@ -52,6 +52,16 @@ class ChatSessionsNotifier extends StateNotifier<List<ChatSession>> {
   void deleteSession(String sessionId) {
     state = state.where((session) => session.id != sessionId).toList();
   }
+
+  void renameSession(String sessionId, String newTitle) {
+    state = [
+      for (final session in state)
+        if (session.id == sessionId)
+          session.copyWith(title: newTitle)
+        else
+          session,
+    ];
+  }
   
   ChatSession? getSessionById(String id) {
     try {


### PR DESCRIPTION
## Summary
- enable renaming chat sessions
- add rename dialog and edit button

## Testing
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d16cb2d688322bda1498b3f9a8b87