### PR TITLE
Add sent image thumbnails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,4 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
-\nflutter/
+flutter/

--- a/README.md
+++ b/README.md
@@ -19,3 +19,4 @@ samples, guidance on mobile development, and a full API reference.
 
 - Attach images to your chat messages.
 - Preview a thumbnail of the attached image before sending.
+- Thumbnail preview appears in the chat after sending a message with an image.

--- a/lib/models/message.dart
+++ b/lib/models/message.dart
@@ -1,10 +1,6 @@
 import 'package:uuid/uuid.dart';
 
-enum MessageRole {
-  user,
-  assistant,
-  system,
-}
+enum MessageRole { user, assistant, system }
 
 extension MessageRoleExtension on MessageRole {
   String get name {
@@ -24,25 +20,29 @@ class Message {
   final MessageRole role;
   final String content;
   final DateTime timestamp;
+  final String? imageBase64;
 
   Message({
     String? id,
     required this.role,
     required this.content,
+    this.imageBase64,
     DateTime? timestamp,
-  })  : id = id ?? const Uuid().v4(),
-        timestamp = timestamp ?? DateTime.now();
+  }) : id = id ?? const Uuid().v4(),
+       timestamp = timestamp ?? DateTime.now();
 
   Message copyWith({
     String? id,
     MessageRole? role,
     String? content,
+    String? imageBase64,
     DateTime? timestamp,
   }) {
     return Message(
       id: id ?? this.id,
       role: role ?? this.role,
       content: content ?? this.content,
+      imageBase64: imageBase64 ?? this.imageBase64,
       timestamp: timestamp ?? this.timestamp,
     );
   }
@@ -52,6 +52,7 @@ class Message {
       'id': id,
       'role': role.toString().split('.').last,
       'content': content,
+      if (imageBase64 != null) 'imageBase64': imageBase64,
       'timestamp': timestamp.toIso8601String(),
     };
   }
@@ -64,6 +65,7 @@ class Message {
         orElse: () => MessageRole.user,
       ),
       content: json['content'],
+      imageBase64: json['imageBase64'],
       timestamp: DateTime.parse(json['timestamp']),
     );
   }

--- a/lib/providers/chat_providers.dart
+++ b/lib/providers/chat_providers.dart
@@ -148,6 +148,7 @@ class ActiveChatSessionNotifier extends StateNotifier<ChatSession?> {
     final userMessage = Message(
       role: MessageRole.user,
       content: content,
+      imageBase64: base64Image,
     );
 
     final updatedSession = state!.addMessage(userMessage);

--- a/lib/ui/widgets/message_bubble.dart
+++ b/lib/ui/widgets/message_bubble.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:intl/intl.dart';
@@ -12,14 +13,18 @@ class MessageBubble extends StatelessWidget {
   Widget build(BuildContext context) {
     final isUser = message.role == MessageRole.user;
     final isSystem = message.role == MessageRole.system;
-    
+
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 4.0),
       child: Column(
-        crossAxisAlignment: isUser ? CrossAxisAlignment.end : CrossAxisAlignment.start,
+        crossAxisAlignment: isUser
+            ? CrossAxisAlignment.end
+            : CrossAxisAlignment.start,
         children: [
           Row(
-            mainAxisAlignment: isUser ? MainAxisAlignment.end : MainAxisAlignment.start,
+            mainAxisAlignment: isUser
+                ? MainAxisAlignment.end
+                : MainAxisAlignment.start,
             children: [
               Text(
                 message.role.name,
@@ -28,8 +33,8 @@ class MessageBubble extends StatelessWidget {
                   color: isSystem
                       ? Colors.orange
                       : isUser
-                          ? Theme.of(context).colorScheme.primary
-                          : Theme.of(context).colorScheme.secondary,
+                      ? Theme.of(context).colorScheme.primary
+                      : Theme.of(context).colorScheme.secondary,
                 ),
               ),
               const SizedBox(width: 8),
@@ -41,36 +46,61 @@ class MessageBubble extends StatelessWidget {
           ),
           const SizedBox(height: 2),
           Container(
-            padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 12.0),
+            padding: const EdgeInsets.symmetric(
+              horizontal: 16.0,
+              vertical: 12.0,
+            ),
             decoration: BoxDecoration(
               color: isUser
                   ? Theme.of(context).colorScheme.primaryContainer
                   : isSystem
-                      ? Theme.of(context).colorScheme.tertiaryContainer
-                      : Theme.of(context).colorScheme.secondaryContainer,
+                  ? Theme.of(context).colorScheme.tertiaryContainer
+                  : Theme.of(context).colorScheme.secondaryContainer,
               borderRadius: BorderRadius.circular(16.0),
             ),
             constraints: BoxConstraints(
               maxWidth: MediaQuery.of(context).size.width * 0.8,
             ),
-            child: isUser
-                ? Text(message.content)
-                : MarkdownBody(
-                    data: message.content,
-                    selectable: true,
-                    styleSheet: MarkdownStyleSheet(
-                      p: Theme.of(context).textTheme.bodyMedium,
-                      code: TextStyle(
-                        backgroundColor: Theme.of(context).colorScheme.surface,
-                        fontFamily: 'monospace',
-                        fontSize: Theme.of(context).textTheme.bodyMedium?.fontSize,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                isUser
+                    ? Text(message.content)
+                    : MarkdownBody(
+                        data: message.content,
+                        selectable: true,
+                        styleSheet: MarkdownStyleSheet(
+                          p: Theme.of(context).textTheme.bodyMedium,
+                          code: TextStyle(
+                            backgroundColor: Theme.of(
+                              context,
+                            ).colorScheme.surface,
+                            fontFamily: 'monospace',
+                            fontSize: Theme.of(
+                              context,
+                            ).textTheme.bodyMedium?.fontSize,
+                          ),
+                          codeblockDecoration: BoxDecoration(
+                            color: Theme.of(context).colorScheme.surface,
+                            borderRadius: BorderRadius.circular(8.0),
+                          ),
+                        ),
                       ),
-                      codeblockDecoration: BoxDecoration(
-                        color: Theme.of(context).colorScheme.surface,
-                        borderRadius: BorderRadius.circular(8.0),
+                if (message.imageBase64 != null)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 8.0),
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(8.0),
+                      child: Image.memory(
+                        base64Decode(message.imageBase64!),
+                        width: 150,
+                        height: 150,
+                        fit: BoxFit.cover,
                       ),
                     ),
                   ),
+              ],
+            ),
           ),
         ],
       ),


### PR DESCRIPTION
## Summary
- support storing optional imageBase64 in `Message`
- include imageBase64 when sending messages with images
- display sent image thumbnails in `MessageBubble`
- document feature in README
- ignore flutter SDK folder

## Testing
- `flutter test` *(fails: Error: Can't find ']' to match '[')*

------
https://chatgpt.com/codex/tasks/task_e_684d6d507bfc8322a65b61d19e100583